### PR TITLE
Fix MA0011 doc - swap DateTime.TryParse parameters

### DIFF
--- a/docs/Rules/MA0011.md
+++ b/docs/Rules/MA0011.md
@@ -8,7 +8,7 @@ More information on Creating Globally Aware Applications here: <https://msdn.mic
 DateTime.TryParse("", out var result);
 
 // Should be
-DateTime.TryParse("", DateTimeStyles.None, CultureInfo.InvariantCulture, out var result);
+DateTime.TryParse("", CultureInfo.InvariantCulture, DateTimeStyles.None, out var result);
 ````
 
 ````csharp


### PR DESCRIPTION
The **DateTimeStyles** and **IFormatProvider** parameters should be swapped.

https://docs.microsoft.com/en-us/dotnet/api/system.datetime.tryparse?view=net-5.0#System_DateTime_TryParse_System_String_System_IFormatProvider_System_Globalization_DateTimeStyles_System_DateTime__

````csharp
public static bool TryParse (string? s, IFormatProvider? provider, System.Globalization.DateTimeStyles styles, out DateTime result);
````